### PR TITLE
Fix remote_addr for audits

### DIFF
--- a/sqlalchemy_continuum/plugins/flask.py
+++ b/sqlalchemy_continuum/plugins/flask.py
@@ -45,7 +45,7 @@ def fetch_remote_addr():
     # Return None if we are outside of request context.
     if _app_ctx_stack.top is None or _request_ctx_stack.top is None:
         return
-    return request.remote_addr
+    return request.headers.get('X-Forwarded-For', None)
 
 
 class FlaskPlugin(Plugin):


### PR DESCRIPTION
Description
-----------
Our audit tables use the flask plugin to automatically track
request `remote_addr`, the IP address where the change is being
made. The X-Forwarded-For request header gives us the client IP,
not the IP of the Aptible load balancer.

Related JIRA Issues
-------------------
SPARK-274

Related Pull Requests
---------------------

Migrations
----------

Extra Deployment Steps
----------------------

Testing Steps
-------------
* check audit log remote_addr